### PR TITLE
Fix links in READMEs

### DIFF
--- a/Notebook/README.md
+++ b/Notebook/README.md
@@ -20,5 +20,5 @@ Comments, corrections, and suggestions for improvement are welcome to be submitt
 
 Furthermore you find the solution snippets we used for the Hands-On-Workshop itself:
 
-- [JupyterNotebook](the-promise-to-partner-workshop.ipynb)
-- [Markdown](the-promise-to-partner-workshop.md)
+- [JupyterNotebook](the-promise-to-partner-Workshop.ipynb)
+- [Markdown](the-promise-to-partner-Workshop.md)

--- a/Notebook/README.md
+++ b/Notebook/README.md
@@ -3,7 +3,7 @@
 In this folder you can find the different versions of the script,
 which was used for the workshop to visualize and analyze a network.
 
-Central is the [JupyterNotebook](the-promise-of-networking.ipynb), which has the programming language R as kernel and is the basis for the export to other formats.
+Central is the [JupyterNotebook](the-promise-to-partner.ipynb), which has the programming language R as kernel and is the basis for the export to other formats.
 
 <!-- The Markdown version is still cleaned up after conversion, for which [Markdownlint](https://github.com/DavidAnson/markdownlint) is used. -->
 
@@ -11,13 +11,12 @@ The [Makefile file](makefile) can be used to generate the various formats:
 
 - [PDF (via LuaLaTeX)](the-promise-to-partner.pdf)
 - [org-mode](the-promise-to-partner.org)
-- [Markdown](the-promise-of-networking.md)
+- [Markdown](the-promise-to-partner.md)
 - [Rscript](the-promise-to-partner.r)
-- [Webpage](the-promise-of-networking.html)
+- [Webpage](the-promise-to-partner.html)
 - [WebSlides](the-promise-to-partner.slides.html)
-- [LaTeX](the-promise-to-partner.tex)
 
-Comments, corrections, and suggestions for improvement are welcome to be submitted as [_Pull Request_](https://github.com/LukasCBossert/the-promise-to-partner/pulls) or entered at [_Issues_](https://github.com/LukasCBossert/the-promise-to-partner/issues).
+Comments, corrections, and suggestions for improvement are welcome to be submitted as [_Pull Request_](https://github.com/LukasCBossert/das-versprechen-der-vernetzung/pulls) or entered at [_Issues_](https://github.com/LukasCBossert/das-versprechen-der-vernetzung/issues).
 
 Furthermore you find the solution snippets we used for the Hands-On-Workshop itself:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In the interactive part of the workshop we worked with JupyterNotebooks.
 The documented sample solution is stored in various formats in the folder [_Notebook_](Notebook/).
 Direct exports from JupyterNotebook are provided in the following formats:
 
-- [JupyterNotebook (R)](Notebook/the-promise-to-partner.ipnyb)
+- [JupyterNotebook (R)](Notebook/the-promise-to-partner.ipynb)
 - [PDF (via LuaLaTeX)](Notebook/the-promise-to-partner.pdf)
 - [org-mode](Notebook/the-promise-to-partner.org)
 - [Markdown](Notebook/the-promise-to-partner.md)

--- a/README.md
+++ b/README.md
@@ -21,14 +21,13 @@ In the interactive part of the workshop we worked with JupyterNotebooks.
 The documented sample solution is stored in various formats in the folder [_Notebook_](Notebook/).
 Direct exports from JupyterNotebook are provided in the following formats:
 
-- [JupyterNotebook (R)](notebook/the-promise-to-partner.ipnyb)
-- [PDF (via LuaLaTeX)](notebook/the-promise-to-partner.pdf)
-- [org-mode](notebook/the-promise-to-partner.org)
-- [Markdown](notebook/the-promise-of-networking.md)
-- [Rscript](notebook/the-promise-to-partner.r)
-- [Webpage](notebook/the-promise-of-networking.html)
-- [WebSlides](notebook/the-promise-to-partner.slides.html)
-- [LaTeX](notebook/the-promise-to-partner.tex)
+- [JupyterNotebook (R)](Notebook/the-promise-to-partner.ipnyb)
+- [PDF (via LuaLaTeX)](Notebook/the-promise-to-partner.pdf)
+- [org-mode](Notebook/the-promise-to-partner.org)
+- [Markdown](Notebook/the-promise-to-partner.md)
+- [Rscript](Notebook/the-promise-to-partner.r)
+- [Webpage](Notebook/the-promise-to-partner.html)
+- [WebSlides](Notebook/the-promise-to-partner.slides.html)
 
 ## License (MIT)
 


### PR DESCRIPTION
This PR fixes some typos in the links in README files.
It corrects some casing issues and old file names. Additionally it removes links to the `.tex` files which are no longer generated (see [here](https://github.com/LukasCBossert/das-versprechen-der-vernetzung/blob/997d23da34171d8580ea8f93b274b5d841caa13a/Notebook/makefile#L22)) as pdfs are generated directly via pandoc.
